### PR TITLE
feat: cli 커맨드 실행 로직 구현 #SM-4 +comment cli 커맨드 실행 로직 구현

### DIFF
--- a/include/commands/command_types.h
+++ b/include/commands/command_types.h
@@ -7,48 +7,62 @@ using namespace std;
 
 /**
  * @brief A 타입 커맨드 실행기
- * 
+ *
  * A 타입 커맨드를 처리하기 위한 실행기 클래스입니다.
  */
-class CommandTypeAExecutor : public ICommandExecutor {
+class CommandTypeAExecutor : public ICommandExecutor
+{
 public:
     /**
      * @brief A 타입 커맨드 실행 메서드
-     * 
+     *
      * @param command 실행할 커맨드 정보
      * @return CommandResult 커맨드 실행 결과
      */
-    CommandResult execute(const CommandResult& command) override;
+    CommandResult execute(const CommandResult &command) override;
 };
 
 /**
  * @brief B 타입 커맨드 실행기
  */
-class CommandTypeBExecutor : public ICommandExecutor {
+class CommandTypeBExecutor : public ICommandExecutor
+{
 public:
-    CommandResult execute(const CommandResult& command) override;
+    CommandResult execute(const CommandResult &command) override;
 };
 
 /**
  * @brief C 타입 커맨드 실행기
  */
-class CommandTypeCExecutor : public ICommandExecutor {
+class CommandTypeCExecutor : public ICommandExecutor
+{
 public:
-    CommandResult execute(const CommandResult& command) override;
+    CommandResult execute(const CommandResult &command) override;
 };
 
 /**
  * @brief D 타입 커맨드 실행기
  */
-class CommandTypeDExecutor : public ICommandExecutor {
+class CommandTypeDExecutor : public ICommandExecutor
+{
 public:
-    CommandResult execute(const CommandResult& command) override;
+    CommandResult execute(const CommandResult &command) override;
 };
 
 /**
  * @brief E 타입 커맨드 실행기
  */
-class CommandTypeEExecutor : public ICommandExecutor {
+class CommandTypeEExecutor : public ICommandExecutor
+{
 public:
-    CommandResult execute(const CommandResult& command) override;
-}; 
+    CommandResult execute(const CommandResult &command) override;
+};
+
+/**
+ * @brief F 타입 커맨드 실행기
+ */
+class CommandTypeFExecutor : public ICommandExecutor
+{
+public:
+    CommandResult execute(const CommandResult &command) override;
+};

--- a/include/operations/cli_operations.h
+++ b/include/operations/cli_operations.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "models/command_result.h"
+#include <string>
+
+using namespace std;
+
+namespace operations
+{
+
+    /**
+     * @brief CLI 작업 클래스
+     *
+     * CLI 작업 모음
+     */
+    class CliOperations
+    {
+    public:
+        /**
+         * @brief CLI 명령어 실행 함수
+         *
+         * @param command 실행할 명령어
+         * @param result 작업 실행 결과
+         * @return CommandResult 작업 실행 결과
+         */
+        static CommandResult executeCli(const string &command, CommandResult &result);
+    };
+
+} // namespace operations

--- a/src/commands/command_executor.cpp
+++ b/src/commands/command_executor.cpp
@@ -39,6 +39,7 @@ void CommandExecutorFactory::initialize()
         executors_["c"] = make_unique<CommandTypeCExecutor>();
         executors_["d"] = make_unique<CommandTypeDExecutor>();
         executors_["e"] = make_unique<CommandTypeEExecutor>();
+        executors_["f"] = make_unique<CommandTypeFExecutor>();
         initialized_ = true;
     }
 }

--- a/src/commands/command_type_f.cpp
+++ b/src/commands/command_type_f.cpp
@@ -1,0 +1,37 @@
+#include "commands/command_types.h"
+#include "operations/cli_operations.h"
+#include "log/logger.h"
+
+using namespace std;
+
+/**
+ * @brief F 타입 명령어를 실행하는 함수
+ *
+ * 이 함수는 client 커맨드 F 타입 명령어를 처리합니다.
+ * 명령어 실행 과정에서 로그를 남기고 적절한 결과 상태를 설정합니다.
+ *
+ * @param command 실행할 명령어 정보가 담긴 CommandResult 객체
+ * @return CommandResult 명령어 실행 결과를 담은 객체
+ * @see CommandResult
+ * @note 현재 구현에서는 항상 성공(1) 상태를 반환합니다
+ */
+CommandResult CommandTypeFExecutor::execute(const CommandResult &command)
+{
+    CommandResult result = command;
+
+    LOG_INFO("F 타입 커맨드 실행 중: ID={}", command.commandID);
+
+    if (command.commandStatus == 1) // 중지
+    {
+        LOG_INFO("cli 명령어 실행 중: ID={}", command.commandID);
+        result = operations::CliOperations::executeCli(command.target, result);
+    }
+    else
+    {
+        LOG_WARN("유효하지 않은 명령어 타입: ID={}, TYPE={}", command.commandID, command.commandType);
+        result.resultStatus = 0;
+        result.resultMessage = "유효하지 않은 명령어 타입";
+    }
+
+    return result;
+}

--- a/src/operations/cli_operations.cpp
+++ b/src/operations/cli_operations.cpp
@@ -1,0 +1,51 @@
+#include "operations/cli_operations.h"
+#include "log/logger.h"
+#include <array>
+#include <memory>
+#include <sstream>
+
+using namespace std;
+
+namespace operations
+{
+
+    CommandResult CliOperations::executeCli(const string &command, CommandResult &result)
+    {
+        LOG_INFO("CLI 명령어 실행 중: {}", command);
+
+        // popen을 사용하여 명령어 실행 및 출력 캡처
+        FILE *pipe = popen(command.c_str(), "r");
+        if (!pipe)
+        {
+            result.resultStatus = 0; // 실패
+            result.resultMessage = "CLI 명령어 실행 실패: 파이프를 열 수 없음";
+            return result;
+        }
+
+        // 명령어 출력 읽기
+        array<char, 4096> buffer;
+        stringstream output;
+
+        size_t bytesRead;
+        while ((bytesRead = fread(buffer.data(), 1, buffer.size() - 1, pipe)) > 0)
+        {
+            buffer[bytesRead] = '\0'; // 문자열 종료 보장
+            output << buffer.data();
+        }
+
+        // 명령어 종료 상태 확인
+        int exitCode = pclose(pipe);
+
+        if (exitCode != 0)
+        {
+            result.resultStatus = 0; // 실패
+            result.resultMessage = "CLI 명령어 실행 실패, 오류 코드: " + to_string(exitCode) + "\n출력: " + output.str();
+            return result;
+        }
+
+        result.resultStatus = 1; // 성공
+        result.resultMessage = output.str();
+
+        return result;
+    }
+} // namespace operations


### PR DESCRIPTION
This pull request introduces a new command type, `CommandTypeFExecutor`, and includes several changes across multiple files to support this addition. The changes also include some refactoring for consistency in the codebase.

### New Command Type Addition:

* [`include/commands/command_types.h`](diffhunk://#diff-af1be87bd7d8acc031bc6de798e128304d6d86cdbb95ab6d3ce8a138af6a555dL27-R65): Added `CommandTypeFExecutor` class definition.
* [`src/commands/command_executor.cpp`](diffhunk://#diff-bd5186b5e40d639173accba5e0fffe1f783c5d06ec024a8379f61380ad620196R42): Registered `CommandTypeFExecutor` in the `CommandExecutorFactory::initialize()` method.
* [`src/commands/command_type_f.cpp`](diffhunk://#diff-26f96f7955e8f9ead486d486e891f2211ab894ebdb7d914b961509f7bbddf668R1-R37): Implemented the `execute` method for `CommandTypeFExecutor`, which handles the execution of F-type commands.

### CLI Operations:

* [`include/operations/cli_operations.h`](diffhunk://#diff-20cdc0de5a10d407f8fff5db36bfbcd089905e2d79fb88642d60f0f6ca61377fR1-R29): Added a new `CliOperations` class with a static method `executeCli` to handle CLI command execution.
* [`src/operations/cli_operations.cpp`](diffhunk://#diff-4ca9b8df28b147d84c0e5646b49b061f919fda801d6f8c44837c7b4bb232e02bR1-R51): Implemented the `executeCli` method to execute CLI commands and capture their output.

### Code Refactoring:

* [`include/commands/command_types.h`](diffhunk://#diff-af1be87bd7d8acc031bc6de798e128304d6d86cdbb95ab6d3ce8a138af6a555dL13-R14): Refactored the formatting of existing command executor classes to place the opening brace `{` on a new line for consistency.