### PR TITLE
feat: docker 배포 구현 완료료 #SM-5

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+build/
+bin/
+docs/
+.github/
+.gitignore
+.git/
+.vscode/
+.idea/
+.DS_Store
+.docs.sh
+.build.sh
+.docker-build.sh
+data.json
+compile_commands.json
+README.md
+Doxyfile.in

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:22.04
+
+# 비대화형 설치 모드 설정 및 시간대 미리 구성
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Seoul
+
+# 해시 불일치 문제 해결을 위한 APT 설정 추가
+RUN echo 'Acquire::http::Pipeline-Depth "0";' > /etc/apt/apt.conf.d/99custom && \
+    echo 'Acquire::CompressionTypes::Order:: "gz";' >> /etc/apt/apt.conf.d/99custom && \
+    echo 'Acquire::http::No-Cache "true";' >> /etc/apt/apt.conf.d/99custom && \
+    echo 'Acquire::BrokenProxy "true";' >> /etc/apt/apt.conf.d/99custom
+
+# APT 설정 업데이트 및 패키지 설치
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get update -o Acquire::Max-FutureTime=86400 --fix-missing && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    pkg-config \
+    libcurl4-openssl-dev \
+    libsystemd-dev \
+    libsensors4-dev \
+    nlohmann-json3-dev \
+    lm-sensors \
+    procps \
+    net-tools \
+    iproute2 \
+    tzdata \
+    libssl-dev \
+    libspdlog-dev \
+    zlib1g-dev \
+    libstatgrab-dev \
+    libncursesw5-dev \
+    libjsoncpp-dev \
+    libprocps-dev \
+    libwebsocketpp-dev \
+    libboost-all-dev \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 작업 디렉토리 생성
+WORKDIR /app
+
+# 소스 코드 복사
+COPY . .
+
+# 빌드 디렉토리 생성 및 빌드 실행
+RUN mkdir -p build && cd build && \
+    cmake .. && \
+    make -j$(nproc)
+
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t system_monitor .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.3'
+
+services:
+  system_monitor:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: system_monitor
+    container_name: system_monitor
+    restart: unless-stopped
+    privileged: true
+    pid: host
+    network_mode: host
+    security_opt:
+      - apparmor:unconfined
+      - seccomp:unconfined
+    cap_add:
+      - ALL
+    volumes:
+      # proc 마운트 제거하고 다른 볼륨만 유지
+      - /sys:/sys:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /etc/os-release:/etc/os-release:ro
+      - /etc/hostname:/etc/hostname:ro
+      - /etc/machine-id:/etc/machine-id:ro
+      - /etc:/etc:ro
+      - /var/log:/var/log:ro
+      - /run/systemd:/run/systemd:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    environment:
+      - TZ=Asia/Seoul
+      - SERVER_ADDR=127.0.0.1:8087
+      - COLLECTION_INTERVAL=2
+      - TRANSFER_INTERVAL=2
+      - SYSTEM_KEY=3fd0c4da2338a62760129b783435ed79218720eaa1298593a655db8e5d0ac22fd24ad0a87494785548db3ed5d5f20cf36459b4baf295eeb1a4461e7c5b4a4096
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/app/bin/client.exec -s $SERVER_ADDR -c $COLLECTION_INTERVAL -t $TRANSFER_INTERVAL -k $SYSTEM_KEY


### PR DESCRIPTION
This pull request introduces a new Docker setup for the project, including a `.dockerignore` file, a `Dockerfile`, a `docker-compose.yml` file, and associated scripts. The changes aim to streamline the building and running of the system monitor application in a Docker environment.

### Docker setup:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R16): Added to exclude unnecessary files and directories from the Docker build context, improving build efficiency.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R56): Created to define the build instructions for the Docker image, including setting up the environment, installing dependencies, and building the application.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R40): Added to define the Docker Compose configuration for running the system monitor application with appropriate settings and volume mappings.

### Supporting scripts:

* [`docker-build.sh`](diffhunk://#diff-b59ca5f840d90f5199bdd3c8208d27d871445ceffa1ea59bf72a31bebd1bab44R1-R2): Introduced a script to automate the Docker image build process.
* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R1-R2): Added an entrypoint script to start the application with the necessary environment variables.